### PR TITLE
Extra/bonus

### DIFF
--- a/module_01/ex01/Zombie.cpp
+++ b/module_01/ex01/Zombie.cpp
@@ -1,5 +1,11 @@
 #include "Zombie.hpp"
 
+
+Zombie::Zombie(void)
+{
+    return;
+}
+
 Zombie::~Zombie(void)
 {
     std::cout << this->name << " -> destroyed"  << std::endl; 

--- a/module_01/ex01/Zombie.hpp
+++ b/module_01/ex01/Zombie.hpp
@@ -12,6 +12,7 @@ private:
     std::string name;
 
 public:
+    Zombie();
     ~Zombie();
 
     void announce(void);

--- a/module_01/ex05/harl.cpp
+++ b/module_01/ex05/harl.cpp
@@ -2,22 +2,22 @@
 
 void Harl::debug( void )
 {
-    std::cout << "DEBUG: 7XL-double-cheese" << std::endl;
+    std::cout << "DEBUG: I love having extra bacon for my 7XL-double-cheese " << std::endl;
 }
 
 
 void Harl::warning( void )
 {
-    std::cout << "WARNING: extra bacon for free" << std::endl;
+    std::cout << "WARNING: I think I deserve to have some extra bacon for free" << std::endl;
 }
 
 void Harl::info( void )
 {
-    std::cout << "INFO: adding extra bacon" << std::endl;
+    std::cout << "INFO: cannot believe adding extra bacon costs more mone" << std::endl;
 }
 void Harl::error( void )
 {
-    std::cout << "ERROR: This is unacceptable! " << std::endl;
+    std::cout << "ERROR: his is unacceptable! I want to speak to the manager now. " << std::endl;
 }
 
 void Harl::complain(std::string level)

--- a/module_01/ex06/harl.cpp
+++ b/module_01/ex06/harl.cpp
@@ -2,22 +2,22 @@
 
 void Harl::debug( void )
 {
-    std::cout << "DEBUG: 7XL-double-cheese" << std::endl;
+    std::cout << "DEBUG: I love having extra bacon for my 7XL-double-cheese " << std::endl;
 }
 
 
 void Harl::warning( void )
 {
-    std::cout << "WARNING: extra bacon for free" << std::endl;
+    std::cout << "WARNING: I think I deserve to have some extra bacon for free" << std::endl;
 }
 
 void Harl::info( void )
 {
-    std::cout << "INFO: adding extra bacon" << std::endl;
+    std::cout << "INFO: cannot believe adding extra bacon costs more mone" << std::endl;
 }
 void Harl::error( void )
 {
-    std::cout << "ERROR: This is unacceptable! " << std::endl;
+    std::cout << "ERROR: his is unacceptable! I want to speak to the manager now. " << std::endl;
 }
 
 void Harl::complain(std::string level)
@@ -32,16 +32,12 @@ void Harl::complain(std::string level)
     {
         case 0:
             (this->*ptr[0])();
-            break;
         case 1:
             (this->*ptr[1])();
-            break;
         case 2:
             (this->*ptr[2])();
-            break;
         case 3:
             (this->*ptr[3])();
-            break;
         default:
             std::cout << "Probably complaining about insignificant problem" << std::endl;
     } 


### PR DESCRIPTION
This pull request introduces a new default constructor for the `Zombie` class and updates the `Harl` class to improve its logging messages and streamline its `complain` method. Below is a summary of the most important changes:

### Updates to the `Zombie` class:

* Added a default constructor `Zombie()` in `Zombie.cpp` and declared it in `Zombie.hpp`. This ensures that `Zombie` objects can now be instantiated without requiring parameters. (`module_01/ex01/Zombie.cpp`, `module_01/ex01/Zombie.hpp`) [[1]](diffhunk://#diff-a6af267e4d7dae3b4c8bf98333e6c9a4db0ff456d0801d580bd746070e87c313R3-R8) [[2]](diffhunk://#diff-bdefd287869220ae8f10c3d38219277cce2149d3a3654c7cb471444a90bf028eR15)

### Updates to the `Harl` class:

* Enhanced the logging messages in the `debug`, `warning`, `info`, and `error` methods to provide more descriptive and expressive outputs. (`module_01/ex05/harl.cpp`, `module_01/ex06/harl.cpp`) [[1]](diffhunk://#diff-d8ca05972b89d9e6006e9c4574512bdfde86730326fd856d4c21f34d8c69a158L5-R20) [[2]](diffhunk://#diff-0a98ed8b0ffe3b8c390d8acb9e35f8299724f6fa1584707cc2ce462107ba4783L5-R20)
* Simplified the `complain` method in `module_01/ex06/harl.cpp` by removing redundant `break` statements from the `switch` cases, as they are unnecessary after `return` calls. (`module_01/ex06/harl.cpp`)